### PR TITLE
PWM frequency over 255 up to 65535 V1.03

### DIFF
--- a/Grove_I2C_Motor_Driver.cpp
+++ b/Grove_I2C_Motor_Driver.cpp
@@ -4,10 +4,10 @@
 
     Copyright (c) 2012 seeed technology inc.
     Website    : www.seeed.cc
-    Author     : Jerry Yip
+    Author     : Jerry Yip , benppppp
     Create Time: 2017-02
     Change Log : 2018-05-31 1.support two phase stepper motor
-                 20204-06-28 (L298) support frequence (V1.03)
+                 20204-06-28 (L298) support frequence (V1.03) needs firmwre update (by benppppp)
 
 * The MIT License (MIT)
  *

--- a/Grove_I2C_Motor_Driver.h
+++ b/Grove_I2C_Motor_Driver.h
@@ -1,33 +1,33 @@
-/*
-    Grove_I2C_Motor_Driver.h
-    A library for Grove - I2C Motor Driver v1.3
-
-    Copyright (c) 2012 seeed technology inc.
-    Website    : www.seeed.cc
-    Author     : Jerry Yip
-    Create Time: 2017-02
-    Change Log :
-
-    The MIT License (MIT)
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-*/
+/* 
+ * Grove_I2C_Motor_Driver.h
+ * A library for Grove - I2C Motor Driver v1.3
+ *
+ * Copyright (c) 2012 seeed technology inc.
+ * Website    : www.seeed.cc
+ * Author     : Jerry Yip
+ * Create Time: 2017-02
+ * Change Log : V1.03 frequence char->int
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #ifndef __I2CMOTORDRIVER_H__
 #define __I2CMOTORDRIVER_H__
@@ -60,10 +60,11 @@
 #define F_30Hz                    0x05
 
 /*************************Class for Grove I2C Motor Driver********************/
-class I2CMotorDriver {
+class I2CMotorDriver
+{
 
-  private:
-    // _speed0: 0~100  _speed1: 0~100
+private:
+    // _speed1: 0~255  _speed2: 0~255
     unsigned char _speed1 = 0;
     unsigned char _speed2 = 0;
     // the direction of M1 and M2 DC motor 1:clockwise  -1:anticlockwise
@@ -76,19 +77,19 @@ class I2CMotorDriver {
     void direction(unsigned char _direction);
     unsigned char _step_cnt = 0;
 
-  public:
+public:
     // Initialize I2C with an I2C address you set on Grove - I2C Motor Driver v1.3
     // default i2c address: 0x0f
-    int begin(unsigned char i2c_add);
+    void begin(unsigned char i2c_add);
     // Set the speed of a motor, speed is equal to duty cycle here
     // motor_id: MOTOR1, MOTOR2
-    // _speed: -100~100, when _speed>0, dc motor runs clockwise;
+    // _speed: -100~100, when _speed>0, dc motor runs clockwise; 
     // when _speed<0, dc motor runs anticlockwise
     void speed(unsigned char motor_id, int _speed);
     // Set the frequence of PWM(cycle length = 510, system clock = 16MHz)
     // F_3921Hz is default
     // _frequence: F_31372Hz, F_3921Hz, F_490Hz, F_122Hz, F_30Hz
-    void frequence(unsigned char _frequence);
+    void frequence(unsigned int _frequence);
     // Stop one motor
     // motor_id: MOTOR1, MOTOR2
     void stop(unsigned char motor_id);
@@ -101,7 +102,7 @@ class I2CMotorDriver {
     //        1 -> 2 phase stepper motor
     //  _mode: 0 -> compatible mode (_step=1 corresponds 4 steps)
     //         1 -> fine mode (_step1 corresponds 1 steps)
-    void StepperRun(int _step, int _type = 0, int _mode = 0);
+    void StepperRun(int _step, int _type = 0, int _mode = 0); 
 };
 
 extern I2CMotorDriver Motor;

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# Grove - I2C Motor Driver v1.3  [![Build Status](https://travis-ci.com/Seeed-Studio/Grove_I2C_Motor_Driver_v1_3.svg?branch=master)](https://travis-ci.com/Seeed-Studio/Grove_I2C_Motor_Driver_v1_3)
-
+# Grove - I2C Motor Driver v1.3 & Grove - I2C Motor Driver (L298P)
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-I2C_Motor_Driver_V1.3/master/img/I2CMotorDriver_New.jpg)
+I2C Motor Driver v1.3
+![105020093_wiki](https://github.com/benppppp/Grove_I2C_Motor_Driver_v1_3/assets/170195651/d3bcfffb-89fe-431c-9900-b96b2edcdd44)
+I2C Motor Driver (L298P)
 
+This library can control both I2C Motor Driver V1.3 and I2C Motor Driver (L298P). Both version use a L298P as motor controler but V1.3 uses a Atmel ATmega8L and (L298) uses a STM32F03.
+You must upgrade (L298P) to last firmwre to be able to change PWM frequence.
 
-The Grove - I2C Motor Driver V1.3 (latest version) can directly control Stepper Motor or DC Motor. Its heart is a dual channel H-bridge driver chip（L298P）that can handle current up to 2A per channel, controlled by an Atmel ATmega8L which handles the I2C communication with for example an Arduino. Both motors can be driven simultaneously while set to a different speed and direction. It can power two brushed DC motors or one 4-wire two-phase stepper motor. It requires a 6V to 15V power supply to power the motor and has an onboard 5V voltage regulator which can power the I2C bus and the Arduino(selectable by jumper). All driver lines are protected by diodes from back-EMF.
+The Grove - I2C Motor Drive can directly control Stepper Motor or DC Motor. Its heart is a dual channel H-bridge driver chip（L298P）that can handle current up to 2A per channel, controlled by an Atmel ATmega8L which handles the I2C communication with for example an Arduino. Both motors can be driven simultaneously while set to a different speed and direction. It can power two brushed DC motors or one 4-wire two-phase stepper motor. It requires a 6V to 15V power supply to power the motor and has an onboard 5V voltage regulator which can power the I2C bus and the Arduino(selectable by jumper). All driver lines are protected by diodes from back-EMF.
 
 - Grove Compatible
 - I2C Interface
@@ -22,7 +26,7 @@ or download the zip.
 
 Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library collection. For example, arduino-1.6.12/libraries. Next time you run the Arduino IDE, you'll have a new option in Sketch -> Include Library -> Grove_I2C_Motor_Driver_v1_3. Review the included examples in Grove_I2C_Motor_Driver_v1_3/examples.
 
-### 1. Set the address of the I2C Motor Driver
+### 1. Set the address of the I2C Motor Driver V1.3
 
 - Set the address by dial switch is a new function added to the new I2C Motor Driver.
 
@@ -37,6 +41,7 @@ Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library colle
       Motor.begin(I2C_ADDRESS);
     }
     ```
+    Note: Default adress in 0x0F for (L298). Adress can be changed via I2C adress pins on PCB.
 
 ### 2. Drive 2 DC motors
 
@@ -47,6 +52,9 @@ Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library colle
 
     // Stop one motor
     void stop(unsigned char motor_id);
+
+    //Set the frequence of motor
+    Motor.frequence(unsigned int _frequence);
     ```
 With speed() function, you are able to drive one motor at the speed you want.
 
@@ -58,6 +66,8 @@ With stop() function, you are able to stop a running DC motor.
 
 **motor_id** represents which motor to use. You can fill MOTOR1 or MOTOR2.
 
+**_frequence** represents the PWM frequence for (L298). For V1.3, choose among: F_31372Hz, F_3921Hz, F_490Hz, F_122Hz, F_30Hz
+Note: Only use frequence when (L298) is upgraded with the latest firmware.
 
 ### 3. Drive a Stepper Motor
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Grove - I2C Motor Driver v1.3 & Grove - I2C Motor Driver (L298P)
+This library can be used for both I2C Motor Driver v1.3 and I2C Motor Driver (L298P)
+New library can run with old (L298) firmware but PWM frequence won't work. You should upgrade library and [firmware](../../../grove_stm32f030/tree/master/firmware/) on (L298): library V1.03 with firmware 103 for example.
+
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-I2C_Motor_Driver_V1.3/master/img/I2CMotorDriver_New.jpg)
 
 *I2C Motor Driver v1.3*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ or download the zip.
 
 Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library collection. For example, arduino-1.6.12/libraries. Next time you run the Arduino IDE, you'll have a new option in Sketch -> Include Library -> Grove_I2C_Motor_Driver_v1_3. Review the included examples in Grove_I2C_Motor_Driver_v1_3/examples.
 
-### 1. Set the address of the I2C Motor Driver V1.3
+### 1. Set the address 
+
+#### On I2C Motor Driver V1.3
 
 - Set the address by dial switch is a new function added to the new I2C Motor Driver.
 
@@ -45,6 +47,13 @@ Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library colle
     }
     ```
     Note: Default adress in 0x0F for (L298). Adress can be changed via I2C adress pins on PCB.
+
+#### On I2C Motor Driver (L298) STM32
+
+Default I2C address is 0x0f
+
+Add jumper on I2C adress connector to change the address
+
 
 ### 2. Drive 2 DC motors
 
@@ -100,4 +109,4 @@ StepperRun(512, 1);
 
 Note that number of pulses for "__step" is 4 (for 2-phase motor), and the number of steps of one motor turn is dependent on the spec of the stepping motor. For example, for the motor with 100 pulse per turn (3.6 degree per pulse), __step=25 will make one turn of the motor.
 
-
+Stepper motor speed cannot be changed from the library. A library update could do it. Contribution welcome!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Grove - I2C Motor Driver v1.3 & Grove - I2C Motor Driver (L298P)
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-I2C_Motor_Driver_V1.3/master/img/I2CMotorDriver_New.jpg)
-I2C Motor Driver v1.3
+
+*I2C Motor Driver v1.3*
+
 ![105020093_wiki](https://github.com/benppppp/Grove_I2C_Motor_Driver_v1_3/assets/170195651/d3bcfffb-89fe-431c-9900-b96b2edcdd44)
-I2C Motor Driver (L298P)
+
+*I2C Motor Driver (L298P)*
 
 This library can control both I2C Motor Driver V1.3 and I2C Motor Driver (L298P). Both version use a L298P as motor controler but V1.3 uses a Atmel ATmega8L and (L298) uses a STM32F03.
 You must upgrade (L298P) to last firmwre to be able to change PWM frequence.
@@ -54,7 +57,7 @@ Simply copy the Grove_I2C_Motor_Driver_v1_3 folder to your Arduino library colle
     void stop(unsigned char motor_id);
 
     //Set the frequence of motor
-    Motor.frequence(unsigned int _frequence);
+    void frequence(unsigned int _frequence);
     ```
 With speed() function, you are able to drive one motor at the speed you want.
 

--- a/examples/dcmotor_test/dcmotor_test.ino
+++ b/examples/dcmotor_test/dcmotor_test.ino
@@ -6,7 +6,7 @@
  * Website    : www.seeed.cc
  * Author     : Jerry Yip, benppppp
  * Create Time: 2017-02
- * Change Log :
+ * Change Log : 2024/05/28 add frequence example
  *
  * The MIT License (MIT)
  *

--- a/examples/dcmotor_test/dcmotor_test.ino
+++ b/examples/dcmotor_test/dcmotor_test.ino
@@ -1,33 +1,33 @@
-/*
-    motor_test.ino
-    Example sketch for Grove - I2C Motor Driver v1.3
-
-    Copyright (c) 2012 seeed technology inc.
-    Website    : www.seeed.cc
-    Author     : Jerry Yip
-    Create Time: 2017-02
-    Change Log :
-
-    The MIT License (MIT)
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-*/
+/* 
+ * motor_test.ino
+ * Example sketch for Grove - I2C Motor Driver v1.3
+ *
+ * Copyright (c) 2012 seeed technology inc.
+ * Website    : www.seeed.cc
+ * Author     : Jerry Yip, benppppp
+ * Create Time: 2017-02
+ * Change Log :
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #include "Grove_I2C_Motor_Driver.h"
 
@@ -35,25 +35,28 @@
 #define I2C_ADDRESS 0x0f
 
 void setup() {
-    Serial.begin(9600);
-    Motor.begin(I2C_ADDRESS);
+  Motor.begin(I2C_ADDRESS);
 }
 
 void loop() {
-    // Set speed of MOTOR1, Clockwise, speed: -100~100
-    Motor.speed(MOTOR1, 50);
-    // Set speed of MOTOR2, Anticlockwise
-    Motor.speed(MOTOR2, -70);
-    delay(2000);
-    // Change speed and direction of MOTOR1
-    Motor.speed(MOTOR1, -100);
-    // Change speed and direction of MOTOR2
-    Motor.speed(MOTOR2, 100);
-    delay(2000);
-    // Stop MOTOR1 and MOTOR2
-    Motor.stop(MOTOR1);
-    Motor.stop(MOTOR2);
-    delay(2000);
+  // Set speed of MOTOR1, Clockwise, speed: -255~255 
+  Motor.speed(MOTOR1, 100);
+  // Set speed of MOTOR2, Anticlockwise
+  Motor.speed(MOTOR2, -120);
+  delay(2000);
+  // Change PWM frequence for both motor
+  // Motor.frequence(1000);//for motor driver STM32 (L298) - Possible frequences 1 - > 65535
+  //Motor.frequence(F_490Hz); //for motor driver 1.3 - Possible frequences F_31372Hz, F_3921Hz, F_490Hz, F_122Hz, F_30Hz
+  // Change speed and direction of MOTOR1
+  Motor.speed(MOTOR1, -255);
+  // Change speed and direction of MOTOR2
+  Motor.speed(MOTOR2, 255);
+  delay(2000);
+  // Stop MOTOR1 and MOTOR2
+  // Can be stopped with speed 0 too!
+  Motor.stop(MOTOR1);
+  Motor.stop(MOTOR2);
+  delay(2000);
 }
 
 // End of file

--- a/examples/dcmotor_test_withoutLibrary/dcmotor_test_withoutLibrary.ino
+++ b/examples/dcmotor_test_withoutLibrary/dcmotor_test_withoutLibrary.ino
@@ -1,0 +1,56 @@
+//Author: benppppp
+//Direction LED should be 2s green and 4s red (no need to connect motor to see that)
+
+#include <Wire.h>
+
+void setup() {
+  Wire.begin();
+}
+
+void loop() {
+   //direction (no motor start without this)
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0xaa);              // Direction control header
+  Wire.write(0x0a);              // send direction control information BothClockWise=0x0a, BothAntiClockWise=0x05, M1CWM2ACW=0x06, M1ACWM2CW=0x09
+  Wire.write(0x01);              // need to send this byte as the third byte(no meaning)
+  Wire.endTransmission();
+
+  //motor PWM frequence (1-65535)
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0x84);              // set pwm frequence header
+  Wire.write(00);                // pwm frequence LSB
+  Wire.write(0x4F);              // pwm frequence MSB
+  Wire.endTransmission();        //frequence=20224 Hz
+
+  //motor speed (0-255)
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0x82);              // set pwm header
+  Wire.write(200);               // send speed of motor1
+  Wire.write(200);               // send speed of motor2
+  Wire.endTransmission();
+
+  delay(2000);
+
+    //direction
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0xaa);              // Direction control header
+  Wire.write(0x05);              // send direction control information BothClockWise=0x0a, BothAntiClockWise=0x05, M1CWM2ACW=0x06, M1ACWM2CW=0x09
+  Wire.write(0x01);              // need to send this byte as the third byte(no meaning)
+  Wire.endTransmission();
+
+  //motor PWM frequence (1-65535)
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0x84);              // set pwm frequence header
+  Wire.write(00);                // pwm frequence LSB
+  Wire.write(0x02);              // pwm frequence MSB
+  Wire.endTransmission();        //frequence=512 Hz
+
+  //motor speed (0-255)
+  Wire.beginTransmission(0x0f);  // begin transmission
+  Wire.write(0x82);              // set pwm header
+  Wire.write(200);               // send speed of motor1
+  Wire.write(200);               // send speed of motor2
+  Wire.endTransmission();
+
+  delay(4000);
+}

--- a/examples/steppermotor_test/steppermotor_test.ino
+++ b/examples/steppermotor_test/steppermotor_test.ino
@@ -4,9 +4,9 @@
 
     Copyright (c) 2012 seeed technology inc.
     Website    : www.seeed.cc
-    Author     : Jerry Yip
+    Author     : Jerry Yip, benppppp
     Create Time: 2017-02
-    Change Log :
+    Change Log : 2024-05-28 Example & comments with motor type and mode
 
     The MIT License (MIT)
 
@@ -36,18 +36,22 @@
 
 
 void setup() {
-    Serial.begin(9600);
-    Motor.begin(I2C_ADDRESS);
-    // Drive a stepper motor
-    // _step: -1024~1024, when _step>0, stepper motor runs clockwise; _step<0, stepper
-    // motor runs anticlockwise; when _step is 512, the stepper motor will run a complete
-    // turn; if step is 1024, the stepper motor will run 2 turns.
-    Motor.StepperRun(-1024);
-    Motor.StepperRun(512);
+  Serial.begin(9600);
+  Motor.begin(I2C_ADDRESS);
+  // Drive a stepper motor
+  //StepperRun(int _step, int _type, int _mode)
+  // _step: -1024~1024, when _step>0, stepper motor runs clockwise; when _step<0,
+  // stepper motor runs anticlockwise; when _step is 512, the stepper motor will
+  // run a complete turn; if step is 1024, the stepper motor will run 2 turns.
+  //  _type: 0 -> 4 phase stepper motor, default
+  //         1 -> 2 phase stepper motor
+  //  _mode: 0 -> compatible mode (_step=1 corresponds 4 steps)
+  //         1 -> fine mode (_step1 corresponds 1 steps)
+  Motor.StepperRun(-1024, 1, 1);
+  Motor.StepperRun(512, 1, 1);
 }
 
 void loop() {
-
 }
 
 // End of file

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Grove I2C Motor Driver v1.3
-version=1.0.1
+version=1.0.3
 author=Seeed Studio
-maintainer=Seeed Studio <techsupport@seeed.cc>
+maintainer=Seeed Studio <techsupport@seeed.cc>, benppppp
 sentence=Arduino library to control Grove I2C Motor Driver.
 paragraph=Arduino library to control Grove I2C Motor Driver.
 category=Sensors


### PR DESCRIPTION
Compatibility with new firmware for (298) with frequency change capability up to 65535.
Solve frequency bug on (L298): https://forum.seeedstudio.com/t/dc-motor-on-i2c-motor-driver-1-3-pwm-is-25hz-and-cant-be-changed
See pull request on grove_stm32f030 for firmware.
Tested on hardware: 2 DC motor and stepper.
Need firmware 103 AND library 1.03 necessary to change frequence
New firmware 103 works with old library 1.01(tested- don't change frequence: 513Hz defaut)
Old firmware works with new library 1.03(tested- don't change frequence: 25Hz default)
It would be a good idea to fork library for Grove_I2C_Motor_Driver_v1_3 and  Grove_I2C_Motor_Driver (L298) because it is difficult to maintain compatibility with old v1.3 card.